### PR TITLE
empty query params with multiple regexes are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The package can be installed by adding `tesla_curl` to your list of dependencies
 ```elixir
 def deps do
   [
-    {:tesla_curl, "~> 1.2.0"}
+    {:tesla_curl, "~> 1.2.1"}
   ]
 end
 ```

--- a/lib/tesla_curl.ex
+++ b/lib/tesla_curl.ex
@@ -148,6 +148,8 @@ defmodule Tesla.Middleware.Curl do
   @spec format_query_params(keyword() | nil) :: String.t()
   defp format_query_params([]), do: nil
 
+  defp format_query_params(params) when params == %{}, do: nil
+
   defp format_query_params(query) do
     "?" <> URI.encode_query(Enum.into(query, %{}), :rfc3986)
   end
@@ -203,8 +205,10 @@ defmodule Tesla.Middleware.Curl do
     end
   end
 
+  defp query_param_redact_for_map(%Regex{}, %{}), do: %{}
+
   defp query_param_redact_for_map(%Regex{} = field, query_params) do
-    Enum.reduce(query_params, field, fn {k, _v}, _acc ->
+    Enum.map(query_params, fn {k, _v} ->
       f = standardize_fields_for_redaction(k)
 
       case Regex.match?(field, f) do
@@ -212,6 +216,7 @@ defmodule Tesla.Middleware.Curl do
         false -> query_params
       end
     end)
+    |> List.first()
   end
 
   # Tesla's spec is a little loose for query params, they can be either a list or map.

--- a/lib/tesla_curl.ex
+++ b/lib/tesla_curl.ex
@@ -218,7 +218,6 @@ defmodule Tesla.Middleware.Curl do
   # Handles field redaction for query params in a list, for atoms, strings, or Regex values in redact_fields
   @spec query_param_redact_for_list(atom() | binary() | Regex.t(), list()) :: list()
   defp query_param_redact_for_list(%Regex{} = field, query_params) do
-    # For each item in query_params, replace the value with "REDACTED" if it matches field, else return the original value
     Enum.map(query_params, fn {k, v} ->
       f = standardize_fields_for_redaction(k)
 

--- a/lib/tesla_curl.ex
+++ b/lib/tesla_curl.ex
@@ -218,12 +218,13 @@ defmodule Tesla.Middleware.Curl do
   # Handles field redaction for query params in a list, for atoms, strings, or Regex values in redact_fields
   @spec query_param_redact_for_list(atom() | binary() | Regex.t(), list()) :: list()
   defp query_param_redact_for_list(%Regex{} = field, query_params) do
-    Enum.reduce(query_params, field, fn {k, _v}, _acc ->
+    # For each item in query_params, replace the value with "REDACTED" if it matches field, else return the original value
+    Enum.map(query_params, fn {k, v} ->
       f = standardize_fields_for_redaction(k)
 
       case Regex.match?(field, f) do
-        true -> Keyword.replace(query_params, k, "REDACTED")
-        false -> query_params
+        true -> {k, "REDACTED"}
+        false -> {k, v}
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule TeslaCurl.MixProject do
       project_url: @project_url,
       start_permanent: Mix.env() == :prod,
       source_url: @project_url,
-      version: "1.2.0"
+      version: "1.2.1"
     ]
   end
 

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -435,18 +435,17 @@ defmodule Tesla.Middleware.CurlTest do
 
     test "handles multiple regexes" do
       assert capture_log(fn ->
-        Tesla.Middleware.Curl.call(
-          %Tesla.Env{
-            method: :get,
-            url: "https://example.com",
-            query: [
-            ]
-          },
-          [],
-          redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/]
-        )
-      end) =~
-        "[info] curl 'https://example.com'"
+               Tesla.Middleware.Curl.call(
+                 %Tesla.Env{
+                   method: :get,
+                   url: "https://example.com",
+                   query: []
+                 },
+                 [],
+                 redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/]
+               )
+             end) =~
+               "[info] curl 'https://example.com'"
     end
   end
 end

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -123,13 +123,13 @@ defmodule Tesla.Middleware.CurlTest do
                    method: :get,
                    url: "https://example.com",
                    headers: [],
-                   body: "<username>some_username</username><password>some password</password>"
+                   body: "<username>some_username</username><password>some password</password><field1>some field</field1>"
                  },
                  [],
-                 redact_fields: [~r{<password>(.*?)</password>}, ~r/<password>(.*?)<\/password>/]
+                 redact_fields: [~r{<password>(.*?)</password>}, ~r/<username>(.*?)<\/username>/]
                )
              end) =~
-               "[info] curl --data '<username>some_username</username><password>REDACTED</password>' 'https://example.com'"
+               "[info] curl --data '<username>REDACTED</username><password>REDACTED</password><field1>some field</field1>' 'https://example.com'"
     end
 
     test "handles regex captures in redact_fields for string request bodies when headers are supplied" do

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -126,7 +126,7 @@ defmodule Tesla.Middleware.CurlTest do
                    body: "<username>some_username</username><password>some password</password>"
                  },
                  [],
-                 redact_fields: [~r{<password>(.*?)</password>}]
+                 redact_fields: [~r{<password>(.*?)</password>}, ~r/<password>(.*?)<\/password>/]
                )
              end) =~
                "[info] curl --data '<username>some_username</username><password>REDACTED</password>' 'https://example.com'"

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -123,7 +123,8 @@ defmodule Tesla.Middleware.CurlTest do
                    method: :get,
                    url: "https://example.com",
                    headers: [],
-                   body: "<username>some_username</username><password>some password</password><field1>some field</field1>"
+                   body:
+                     "<username>some_username</username><password>some password</password><field1>some field</field1>"
                  },
                  [],
                  redact_fields: [~r{<password>(.*?)</password>}, ~r/<username>(.*?)<\/username>/]
@@ -457,7 +458,11 @@ defmodule Tesla.Middleware.CurlTest do
                    query: %{}
                  },
                  [],
-                 redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/, "field1"]
+                 redact_fields: [
+                   ~r/<username>(.*?)<\/username>/,
+                   ~r/<password>(.*?)<\/password>/,
+                   "field1"
+                 ]
                )
              end) =~
                "[info] curl 'https://example.com'"

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -433,7 +433,7 @@ defmodule Tesla.Middleware.CurlTest do
                "[info] curl -X POST --header 'Authorization: REDACTED' --data 'foo=REDACTED' 'https://example.com'"
     end
 
-    test "handles multiple regexes" do
+    test "handles multiple regexes with empty query list" do
       assert capture_log(fn ->
                Tesla.Middleware.Curl.call(
                  %Tesla.Env{
@@ -443,6 +443,21 @@ defmodule Tesla.Middleware.CurlTest do
                  },
                  [],
                  redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/]
+               )
+             end) =~
+               "[info] curl 'https://example.com'"
+    end
+
+    test "handles multiple regexes with empty query map" do
+      assert capture_log(fn ->
+               Tesla.Middleware.Curl.call(
+                 %Tesla.Env{
+                   method: :get,
+                   url: "https://example.com",
+                   query: %{}
+                 },
+                 [],
+                 redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/, "field1"]
                )
              end) =~
                "[info] curl 'https://example.com'"

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -432,5 +432,21 @@ defmodule Tesla.Middleware.CurlTest do
              end) =~
                "[info] curl -X POST --header 'Authorization: REDACTED' --data 'foo=REDACTED' 'https://example.com'"
     end
+
+    test "handles multiple regexes" do
+      assert capture_log(fn ->
+        Tesla.Middleware.Curl.call(
+          %Tesla.Env{
+            method: :get,
+            url: "https://example.com",
+            query: [
+            ]
+          },
+          [],
+          redact_fields: [~r/<username>(.*?)<\/username>/, ~r/<password>(.*?)<\/password>/]
+        )
+      end) =~
+        "[info] curl 'https://example.com'"
+    end
   end
 end


### PR DESCRIPTION
Fix an edge case where if an empty query params was sent with regex fields to redact, the accumulator would return the regular expressions and choke out.