### PR TITLE
allows for usage of formatter/logger without middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ plug Tesla.Middleware.Curl, follow_redirects: true, redact_fields: ["api_token",
 
 ## License
 
-The source code is under the MIT License. Copyright (c) 2023-2024 Colin Cromar.
+The source code is under the MIT License. Copyright (c) 2023-2025 Colin Cromar.

--- a/test/tesla_curl_test.exs
+++ b/test/tesla_curl_test.exs
@@ -472,18 +472,18 @@ defmodule Tesla.Middleware.CurlTest do
   describe "log/2" do
     test "parses the request, logs it, and returns :ok" do
       assert capture_log(fn ->
-        env = %Tesla.Env{
-          method: :post,
-          url: "https://example.com",
-          headers: [{:Authorization, "some_token"}],
-          body: %{foo: "bar"}
-        }
+               env = %Tesla.Env{
+                 method: :post,
+                 url: "https://example.com",
+                 headers: [{:Authorization, "some_token"}],
+                 body: %{foo: "bar"}
+               }
 
-        options = [redact_fields: ["authorization", "Foo"]]
+               options = [redact_fields: ["authorization", "Foo"]]
 
-        Tesla.Middleware.Curl.log(env, options)
-      end) =~
-        "[info] curl -X POST --header 'Authorization: REDACTED' --data 'foo=REDACTED' 'https://example.com'"
+               Tesla.Middleware.Curl.log(env, options)
+             end) =~
+               "[info] curl -X POST --header 'Authorization: REDACTED' --data 'foo=REDACTED' 'https://example.com'"
     end
 
     test "logs error and returns :ok" do


### PR DESCRIPTION
adds a new entrypoint, `log/2` that allows for usage of the library without using the middleware chaining.